### PR TITLE
If two path_tokens are present, still do the shortening.

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -223,7 +223,7 @@ class Tulle < Sinatra::Base
         if uri.host == "diamond.temple.edu"
           path_tokens = uri.path.split(/[=,~]/)
           logger.info "path tokens: " + path_tokens.to_s
-          if path_tokens.length > 2
+          if path_tokens.length >= 2
             item_id = path_tokens[1]
             if !item_id.nil? and !item_id.empty?
               logger.info "item id: " + item_id.to_s


### PR DESCRIPTION
When the diamond link path is split, two, not more than two, path tokens are needed to know if we have a diamond id.

This prevents the link exchanger from erroring out on links that don't have the scope at the end, ie "~20"