### PR TITLE
Explicitly make primo urls a string, else you can't check if empty

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -170,7 +170,7 @@ class Tulle < Sinatra::Base
       end
       if !primoid.empty?
         primo_query =  + @@PRIMO_ITEM_QUERY + primoid + @@PRIMO_ITEM_AFFIX
-        perm_url = URI::HTTPS.build(:scheme => @@PRIMO_HOSTED_SCHEME, :host => @@PRIMO_HOST, :path => @@PRIMO_ITEM_PATH, :query => primo_query )
+        perm_url = URI::HTTPS.build(:scheme => @@PRIMO_HOSTED_SCHEME, :host => @@PRIMO_HOST, :path => @@PRIMO_ITEM_PATH, :query => primo_query ).to_s
       else
         puts "get_perm_path ERROR: " + almaid.to_s + " not found in primo db"
       end

--- a/app/views/index.erb
+++ b/app/views/index.erb
@@ -52,7 +52,7 @@
   </div>
     <div class="internal">
       <p>
-      Exchange Diamond <!-- Diamond/Primo --> links for permanent Temple URLs:
+      Exchange Primo links for permanent Temple URLs:
     </p>
     </div>
     <div class="internal">


### PR DESCRIPTION
All diamond URLs were breaking with the error

`redirect error undefined method `empty?' for #<URI::HTTPS:0x0055bf79e2f5c0>`